### PR TITLE
Suggested patch for spork testunit

### DIFF
--- a/bin/testdrb
+++ b/bin/testdrb
@@ -2,7 +2,7 @@
 
 
 require 'drb'
-DRb.start_service("druby://localhost:0") # this allows Ruby to do some magical stuff so you can pass an output stream over DRb.
+DRb.start_service("druby://127.0.0.1:0") # this allows Ruby to do some magical stuff so you can pass an output stream over DRb.
 test_server = DRbObject.new_with_uri("druby://127.0.0.1:8988")
 result = test_server.run(ARGV, $stderr, $stdout)
 


### PR DESCRIPTION
Hi Tim,

spork testunit helps us out so much.

I made one line change to fix an error a number of developers here are having.

On Mac OSX, it fails on the client trying to connect to the server
# testdrb test/unit/worker_command_test.rb

/Users/kbrock/.rvm/rubies/ruby-1.8.7-p174/lib/ruby/1.8/drb/drb.rb:866:in `initialize': getaddrinfo: nodename nor servname provided, or not known (SocketError)
...
    from /lib/ruby/1.8/drb/drb.rb:1635:in`start_service'
    from /spork-testunit-0.0.2/bin/testdrb:5
    from /bin/testdrb:19:in `load'
    from /bin/testdrb:19

This patch fixes it for me

Thanks,
Keenan
