### PR TITLE
Better error messages for syntax errors

### DIFF
--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -8,7 +8,11 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
     r = Test::Unit::AutoRunner.new(true)
     exit(false) unless r.process_args(argv)
     r.run
-  rescue
-    puts 'error'
+  rescue => e
+    puts "-"*30
+    puts "Error executing #{argv.join(' ')}"
+    puts e.message
+    puts e.backtrace
+    puts "-"*30
   end
 end


### PR DESCRIPTION
Hey Tim,

Loving Spork!

1) When I have a syntax error in a test file, spork just say 'error'.
I am all set for this fix, but thought to send across if you are also pushing across other changes.

2) Also, I'm using watchr to implement an autotest on top of spork. you interested? Where is the best place to share?

Thanks again for spork,
Keenan
