### PR TITLE
Issue #2

### DIFF
--- a/bin/testdrb
+++ b/bin/testdrb
@@ -1,5 +1,12 @@
 #!/usr/bin/env ruby
 
+# These fix 1.8.7 test/unit results where a DRbUnknown is returned because the testdrb client doesn't have the classes
+# in its local namespace.  (See issue #2)
+unless defined? MiniTest
+  # MiniTest is Ruby 1.9, and the classes below only exist in the pre 1.9 test/unit
+  require 'test/unit/testresult'
+  require 'test/unit/failure'
+end
 
 require 'drb'
 DRb.start_service("druby://127.0.0.1:0") # this allows Ruby to do some magical stuff so you can pass an output stream over DRb.


### PR DESCRIPTION
Hi Tim,

This is a fix for the DrbUnknown output described in issue #2 for Ruby 1.8 test/unit console runner.  I wrote up the test example in the #2 comments.  I didn't test Ruby 1.9, but wrapped the requires in a test for MiniTest so I don't think they'll bother 1.9.  Glancing at MiniTest, I doubt it has the same issues, as it looked like it was only passing back Strings.

thanks,
Josh Partlow
