### PR TITLE
Add ruby-head compat

### DIFF
--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -15,22 +15,34 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
         end
       }
 
-      # copied from ruby-1.9.2-p136/bin/testrb:
-      require 'test/unit'
-      Test::Unit.setup_argv(argv) {|files|
-        if files.empty?
-          puts "Usage: testrb [options] tests..."
-          exit 1
-        end
-        if files.size == 1
-          $0 = File.basename(files[0])
-        else
-          $0 = files.to_s
-        end
-        files
-      }
+      require 'test/unit'                                                                                         
+      if Test::Unit.respond_to?(:setup_argv)
+        # copied from ruby-1.9.2-p136/bin/testrb:
+        Test::Unit.setup_argv(argv) {|files|
+          if files.empty?
+            puts "Usage: testrb [options] tests..."
+            exit 1
+          end
+          if files.size == 1
+            $0 = File.basename(files[0])
+          else
+            $0 = files.to_s
+          end
+          files
+        }
 
-      MiniTest::Unit.new.run(argv)
+        MiniTest::Unit.new.run(argv)
+      else
+        # copied from ruby-head/bin/testrb:
+        tests = Test::Unit::AutoRunner.new(true)
+        tests.options.banner.sub!(/\[options\]/, '\& tests...')
+        unless tests.process_args(argv)
+          abort tests.options.banner
+        end
+        files = tests.to_run
+        $0 = files.size == 1 ? File.basename(files[0]) : files.to_s
+        tests.run
+      end
     else
       # Ruby 1.8
       Object.send(:remove_const, :STDOUT); Object.send(:const_set, :STDOUT, stdout)


### PR DESCRIPTION
ruby-head does not have the setup_arv method.  

We are using ruby-head because its new performance improvements.
