### PR TITLE
MiniTest testdrb fix

### DIFF
--- a/bin/testdrb
+++ b/bin/testdrb
@@ -2,7 +2,9 @@
 
 # These fix 1.8.7 test/unit results where a DRbUnknown is returned because the testdrb client doesn't have the classes
 # in its local namespace.  (See issue #2)
-unless defined? MiniTest
+begin
+  require 'minitest/unit'
+rescue LoadError
   # MiniTest is Ruby 1.9, and the classes below only exist in the pre 1.9 test/unit
   require 'test/unit/testresult'
   require 'test/unit/failure'


### PR DESCRIPTION
The previous `unless defined? MiniTest` **never** evaluated to false even when using MiniTest because the MiniTest constant isn't defined until you require something.
