### PR TITLE
Make spork-testunit work with turn

### DIFF
--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -25,7 +25,16 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
       argv.compact!
 
       require 'test/unit'                                                                                         
-      if Test::Unit.respond_to?(:setup_argv)
+      if defined? Turn
+        # Use turn's wrapper around minitest
+        runner = Turn::MiniRunner.new
+        config = Turn.config do |c|
+          c.tests     = argv
+          c.framework = :minitest
+        end
+        controller = Turn::Controller.new(config)
+        controller.start
+      elsif Test::Unit.respond_to?(:setup_argv)
         # copied from ruby-1.9.2-p136/bin/testrb:
         Test::Unit.setup_argv(argv) {|files|
           if files.empty?

--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -27,6 +27,10 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
       require 'test/unit'                                                                                         
       if defined? Turn
         # Use turn's wrapper around minitest
+        if argv.empty?
+          puts "Usage: testrb [options] tests..."
+          exit 1
+        end
         runner = Turn::MiniRunner.new
         config = Turn.config do |c|
           c.tests     = argv


### PR DESCRIPTION
This change makes spork-testunit check for the existence of Turn. If it is there, it runs the tests under Turn's wrapper around MiniTest instead of using MiniTest itself.

You can take this if you like it. I'm using it in my project which uses Turn and MiniTest.
