### PR TITLE
Added support for -r and -e

### DIFF
--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -7,7 +7,7 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
       # Ruby 1.9
       MiniTest::Unit.output = stdout
 
-      # MiniTest's test/unit does not support -I or -r
+      # MiniTest's test/unit does not support -I, -r, or -e
       # Extract them and remove from arguments that are passed to testrb.
       argv.each_with_index do |arg, idx|
         if arg =~ /-I(.*)/
@@ -30,6 +30,9 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
           end
           require require_file
           argv[idx] = nil
+        elsif arg =~ /^-e$/
+          eval argv[idx + 1]
+          argv[idx] = argv[idx + 1] = nil
         end
       end
       argv.compact!

--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -7,8 +7,8 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
       # Ruby 1.9
       MiniTest::Unit.output = stdout
 
-      # MiniTest's test/unit does not support -I
-      # Extract it and remove from arguments that are passed to testrb.
+      # MiniTest's test/unit does not support -I or -r
+      # Extract them and remove from arguments that are passed to testrb.
       argv.each_with_index do |arg, idx|
         if arg =~ /-I(.*)/
           if $1 == ''
@@ -19,6 +19,16 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
             include_path = $1
           end
           $LOAD_PATH << include_path
+          argv[idx] = nil
+        elsif arg =~ /-r(.*)/
+          if $1 == ''
+            # File is next argument.
+            require_file = argv[idx + 1]
+            argv[idx + 1] = nil # Will be squashed when compact called.
+          else
+            require_file = $1
+          end
+          require require_file
           argv[idx] = nil
         end
       end


### PR DESCRIPTION
`-r` allows executing a `require` statement from the command line.

`-e` allows executing arbitrary ruby from the command line.

These two options will enable a fix for issue guard/guard-minitest#11 in the `guard-minitest` repo: "No notification when running with spork server." With the fix, you can run your test suite under `guard` with `spork` and `test-unit`, and get a `growl` notification (if you wish) when each time the tests are complete. 

I am about to send a pull request in the guard-minitest repo asking them to take the other part of this fix. 
