### PR TITLE
Feature/drbport

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -4,4 +4,4 @@ This includes a plugin for spork to enable Test::Unit support for spork. It also
 
 To use it, install the gem, then fire up spork in your project directory (the file test/test_helper.rb must exist to detect that Test::Unit is being used).
 
-Then, once spork is running, invoke `testdrb test/your_test.rb` to run your tests under Spork. To use another port than the default run `testdrb test/your_test.rb drbport=1234`.
+Then, once spork is running, invoke `testdrb test/your_test.rb` to run your tests under Spork. To use another port than the default run `testdrb test/your_test.rb --port=1234`.

--- a/README.textile
+++ b/README.textile
@@ -4,4 +4,4 @@ This includes a plugin for spork to enable Test::Unit support for spork. It also
 
 To use it, install the gem, then fire up spork in your project directory (the file test/test_helper.rb must exist to detect that Test::Unit is being used).
 
-Then, once spork is running, invoke `testdrb test/your_test.rb` to run your tests under Spork.
+Then, once spork is running, invoke `testdrb test/your_test.rb` to run your tests under Spork. To use another port than the default run `testdrb test/your_test.rb drbport=1234`.

--- a/bin/testdrb
+++ b/bin/testdrb
@@ -10,8 +10,11 @@ rescue LoadError
   require 'test/unit/failure'
 end
 
+drbport = 8988
+ARGV.delete_if {|arg| drbport = arg.split('=')[1] if arg.start_with?('drbport=')}
+
 require 'drb'
 DRb.start_service("druby://127.0.0.1:0") # this allows Ruby to do some magical stuff so you can pass an output stream over DRb.
-test_server = DRbObject.new_with_uri("druby://127.0.0.1:8988")
+test_server = DRbObject.new_with_uri("druby://127.0.0.1:#{drbport}")
 result = test_server.run(ARGV, $stderr, $stdout)
 

--- a/bin/testdrb
+++ b/bin/testdrb
@@ -11,7 +11,7 @@ rescue LoadError
 end
 
 drbport = 8988
-ARGV.delete_if {|arg| drbport = arg.split('=')[1] if arg.start_with?('drbport=')}
+ARGV.delete_if {|arg| drbport = arg.split('=')[1] if arg.start_with?('--port=')}
 
 require 'drb'
 DRb.start_service("druby://127.0.0.1:0") # this allows Ruby to do some magical stuff so you can pass an output stream over DRb.


### PR DESCRIPTION
Enable users to specify a different port number for the Spork server by adding drbport=1234 to the command (where 1234 is the port number). 
