### PR TITLE
Add test/ to Turn's loadpath

### DIFF
--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -7,7 +7,7 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
       # Ruby 1.9
       stdout = Purdytest::IO.new(stdout) if defined? Purdytest # rewrap
       MiniTest::Unit.output = stdout
-
+      old_load_path = $LOAD_PATH.dup
       # MiniTest's test/unit does not support -I, -r, or -e
       # Extract them and remove from arguments that are passed to testrb.
       argv.each_with_index do |arg, idx|
@@ -49,7 +49,7 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
         config = Turn.config do |c|
           c.tests     = argv
           c.framework = :minitest
-          c.loadpath << 'test' unless c.loadpath.include?('test')
+          c.loadpath = (c.loadpath + $LOAD_PATH - old_load_path).uniq
         end
         controller = Turn::Controller.new(config)
         controller.start

--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -49,6 +49,7 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
         config = Turn.config do |c|
           c.tests     = argv
           c.framework = :minitest
+          c.loadpath << 'test' unless c.loadpath.include?('test')
         end
         controller = Turn::Controller.new(config)
         controller.start


### PR DESCRIPTION
Hi, 

Currently sport-testunit doesn't work well with turn out of box. I have to set something like `Turn.config.loadpath << 'test'` in the test_helper.rb, otherwise I will get `Exception encountered: #<LoadError: cannot load such file -- test_helper>`. Set this by default might be convenient.
