### PR TITLE
Checks for minispec_helper.rb in spec directory.

### DIFF
--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -1,6 +1,8 @@
 class Spork::TestFramework::TestUnit < Spork::TestFramework
   DEFAULT_PORT = 8988
-  HELPER_FILE = File.join(Dir.pwd, "test/test_helper.rb")
+  HELPER_FILE  = ["spec/minispec_helper.rb", "test/test_helper.rb"].map do |p|
+                   File.exist?(f = File.join(Dir.pwd, p)) ? f : nil
+                 end.compact.last
 
   def run_tests(argv, stderr, stdout)
     if defined? MiniTest


### PR DESCRIPTION
This is so people can use the Spec DSL of MiniTest and keep it in the spec directory.
