### PR TITLE
Be more strict in parsing arguments in run_tests

### DIFF
--- a/lib/spork/test_framework/test_unit.rb
+++ b/lib/spork/test_framework/test_unit.rb
@@ -13,7 +13,7 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
       # MiniTest's test/unit does not support -I, -r, or -e
       # Extract them and remove from arguments that are passed to testrb.
       argv.each_with_index do |arg, idx|
-        if arg =~ /-I(.*)/
+        if arg =~ /^-I(.*)/
           if $1 == ''
             # Path is next argument.
             include_path = argv[idx + 1]
@@ -23,7 +23,7 @@ class Spork::TestFramework::TestUnit < Spork::TestFramework
           end
           $LOAD_PATH << include_path
           argv[idx] = nil
-        elsif arg =~ /-r(.*)/
+        elsif arg =~ /^-r(.*)/
           if $1 == ''
             # File is next argument.
             require_file = argv[idx + 1]


### PR DESCRIPTION
In run_tests, when iterating over argv in Spork::TestFramework::TestUnit.run_tests the arguments are matched against /-I(._)/ to check for include paths and against /-r(._)/ to check for required files.

The problem is that these regexes match anywhere in any argument, but should match only the start of the arguments as otherwise any appearance of the sequences "-I" and "-r" in an argument will match and result in misbehaviour.

For example when trying to run a test "/home/me/my-rails-project/test/unit/test_test.rb" the "-r" in "my-rails-project" will match and run_tests will require the file "ails-project/test/unit/test_test.rb".

This is fixed by anchoring both of the regexes to the beginning of the string.
